### PR TITLE
bugfix, delete pop up

### DIFF
--- a/components/DeletePopUp.js
+++ b/components/DeletePopUp.js
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components";
 export default function DeletePopUp({ onDelete, onCancel }) {
   return (
     <WarningOverlay onClick={onCancel}>
-      <StyledPopUpWarning>
+      <StyledPopUpWarning onClick={event => event.stopPropagation()}>
         <StyledWarningMessage>
           Are you sure you want to delete this plant? This decision is not
           reversible!


### PR DESCRIPTION
 clicking on the pop up used to close the warning. now only clicking on the background will do that. 